### PR TITLE
fix: toggle for play and pause

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 ## Description
 This is a [Touch Portal](https://www.touch-portal.com/) plugin for the [YouTube Music Desktop Application](https://ytmdesktop.app/).
 
-The project was inspired by original plugin written by [KillerBOSS](https://github.com/DamienStaebler/TP-YTDM-Plugin)
+The project was inspired by original plugin written by [KillerBOSS](https://github.com/DamienStaebler/TP-YTMD-Plugin)

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,4 @@
+## Credit for Icon:
+<a href="https://www.flaticon.com/free-icons/music-player" title="music player icons">Music player icons created by Those Icons - Flaticon</a>
+<br><br>
+![image](/assets/icon.png)

--- a/config/entry.tp
+++ b/config/entry.tp
@@ -32,48 +32,52 @@
           "id": "ytmd.action.play/pause",
           "name": "YouTube Music Playback Play/Pause",
           "type": "communicate",
-          "tryInline": "true",
           "lines": {
             "action": [
               {
                 "language": "default",
                 "data": [
                   {
-                    "id": "ytmd.action.play/pause",
-                    "type": "choice",
-                    "default": "Play",
-                    "valueChoices": [
-                      "Pause",
-                      "Play",
-                      "Toggle"
-                    ]
+                    "lineFormat": "YouTube Music play state {$ytmd.choice.playState$}"
                   }
                 ]
               }
             ]
-          }
+          },
+          "data": [
+            {
+              "id": "ytmd.choice.playState",
+              "type": "choice",
+              "default": "Toggle",
+              "valueChoices": [
+                "Pause",
+                "Play",
+                "Toggle"
+              ]
+            }
+          ]
         }
       ],
       "events": [
         {
-          "id": "ytmd.events.isPaused",
+          "id": "ytmd.event.playback",
           "name": "YouTube Music play state changes",
           "format": "When YouTube Music is $val",
           "type": "communicate",
           "valueType": "choice",
           "valueChoices": [
-            "PLAYING",
-            "PAUSED"
+            "Play",
+            "Pause"
           ],
-          "valueStateId": "ytmd.states.isPaused"
+          "valueStateId": "ytmd.states.playbackState"
         }
       ],
       "states": [
         {
-          "id": "ytmd.states.isPaused",
+          "id": "ytmd.states.playbackState",
           "type": "text",
           "desc": "YouTube Music play state paused",
-          "default": "PAUSED"
+          "default": "Pause"
         }
       ]
     }

--- a/config/entry.tp
+++ b/config/entry.tp
@@ -111,10 +111,75 @@
             {
               "id": "ytmd.choice.audioPlayback",
               "type": "choice",
-              "default": "Unmuted",
+              "default": "Toggle",
               "valueChoices": [
                 "Muted",
-                "Unmuted"
+                "Unmuted",
+                "Toggle"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "ytmd.action.volumeUp",
+          "name": "Volume Up",
+          "type": "communicate",
+          "lines": {
+            "action": [
+              {
+                "language": "default",
+                "data": [
+                  {
+                    "lineFormat": "Volume Up"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "id": "ytmd.action.volumeDown",
+          "name": "Volume Down",
+          "type": "communicate",
+          "lines": {
+            "action": [
+              {
+                "language": "default",
+                "data": [
+                  {
+                    "lineFormat": "Volume Down"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "id": "ymtd.action.repeatMode",
+          "name": "YouTube Music Repeat Mode",
+          "type": "communicate",
+          "lines": {
+            "action": [
+              {
+                "language": "default",
+                "data": [
+                  {
+                    "lineFormat": "YouTube Music repeat mode {$ytmd.choice.repeatMode$}"
+                  }
+                ]
+              }
+            ]
+          },
+          "data": [
+            {
+              "id": "ytmd.choice.repeatMode",
+              "type": "choice",
+              "default": "Toggle",
+              "valueChoices": [
+                "NONE",
+                "ALL",
+                "ONE",
+                "Toggle"
               ]
             }
           ]
@@ -144,6 +209,19 @@
             "Unmuted"
           ],
           "valueStateId": "ytmd.states.mutedState"
+        },
+        {
+          "id": "ytmd.event.repeatMode",
+          "name": "YouTube Music repeat mode changes",
+          "format": "When repeat mode is $val",
+          "type": "communicate",
+          "valueType": "choice",
+          "valueChoices": [
+            "NONE",
+            "ALL",
+            "ONE"
+          ],
+          "valueStateId": "ytmd.states.repeatMode"
         }
       ],
       "states": [
@@ -158,6 +236,12 @@
           "type": "text",
           "desc": "YouTube Music audio state (Mutes or Unmuted)",
           "default": "Unmuted"
+        },
+        {
+          "id": "ytmd.states.repeatMode",
+          "type": "text",
+          "desc": "YouTube Music repeat mode (NONE, ALL, ONE)",
+          "default": "NONE"
         }
       ]
     }

--- a/config/entry.tp
+++ b/config/entry.tp
@@ -212,6 +212,34 @@
               ]
             }
           ]
+        },
+        {
+          "id": "ytmd.action.like/dislike",
+          "name": "Track Like/Dislike",
+          "type": "communicate",
+          "lines": {
+            "action": [
+              {
+                "language": "default",
+                "data": [
+                  {
+                    "lineFormat": "Track is {$ytmd.choice.likeDislike$}"
+                  }
+                ]
+              }
+            ]
+          },
+          "data": [
+            {
+              "id": "ytmd.choice.likeDislike",
+              "default": "",
+              "type": "choice",
+              "valueChoices": [
+                "DISLIKE",
+                "LIKE"
+              ]
+            }
+          ]
         }
       ],
       "events": [
@@ -263,6 +291,19 @@
             "ON"
           ],
           "valueStateId": "ytmd.states.shuffleMode"
+        },
+        {
+          "id": "ytmd.event.likeDislike",
+          "name": "Track Like/Dislike",
+          "format": "When track is $val",
+          "type": "communicate",
+          "valueType": "choice",
+          "valueChoices": [
+            "DISLIKE",
+            "INDIFFERENT",
+            "LIKE"
+          ],
+          "valueStateId": "ytmd.states.likeDislike"
         }
       ],
       "states": [
@@ -289,6 +330,17 @@
           "type": "text",
           "desc": "YouTube Music shuffle mode (OFF, ON)",
           "default": "OFF"
+        },
+        {
+          "id": "ytmd.states.likeDislike",
+          "type": "text",
+          "desc": "Track Like/Dislike (DISLIKE, INDIFFERENT, LIKE)",
+          "default": "INDIFFERENT",
+          "valueChoices": [
+            "DISLIKE",
+            "INDIFFERENT",
+            "LIKE"
+          ]
         }
       ]
     }

--- a/config/entry.tp
+++ b/config/entry.tp
@@ -56,7 +56,59 @@
               ]
             }
           ]
+        },
+        {
+          "id": "ytmd.action.nextTrack",
+          "name": "Play Next Track",
+          "type": "communicate",
+          "lines": {
+            "action": [
+              {
+                "language": "default",
+                "data": [
+                  {
+                    "lineFormat": "Play next track"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "id": "ytmd.action.prevTrack",
+          "name": "Play Previous Track",
+          "type": "communicate",
+          "lines": {
+            "action": [
+              {
+                "language": "default",
+                "data": [
+                  {
+                    "lineFormat": "Play previous track"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "id": "ytmd.action.mute/unmute",
+          "name": "Mute/Unmute",
+          "type": "communicate",
+          "lines": {
+            "action": [
+              {
+                "language": "default",
+                "data": [
+                  {
+                    "lineFormat": "Current audio state: "
+                  }
+                ]
+              }
+            ]
+          }
         }
+        
       ],
       "events": [
         {

--- a/config/entry.tp
+++ b/config/entry.tp
@@ -155,7 +155,7 @@
           }
         },
         {
-          "id": "ymtd.action.repeatMode",
+          "id": "ytmd.action.repeatMode",
           "name": "YouTube Music Repeat Mode",
           "type": "communicate",
           "lines": {
@@ -179,6 +179,35 @@
                 "NONE",
                 "ALL",
                 "ONE",
+                "Toggle"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "ytmd.action.shuffleMode",
+          "name": "Shuffle On/Off",
+          "type": "communicate",
+          "lines": {
+            "action": [
+              {
+                "language": "default",
+                "data": [
+                  {
+                    "lineFormat": "YouTube Music shuffle mode {$ytmd.choice.shuffleMode$}"
+                  }
+                ]
+              }
+            ]
+          },
+          "data": [
+            {
+              "id": "ytmd.choice.shuffleMode",
+              "type": "choice",
+              "default": "Toggle",
+              "valueChoices": [
+                "OFF",
+                "ON",
                 "Toggle"
               ]
             }
@@ -222,6 +251,18 @@
             "ONE"
           ],
           "valueStateId": "ytmd.states.repeatMode"
+        },
+        {
+          "id": "ytmd.event.shuffleMode",
+          "name": "YouTube Music shuffle mode changes",
+          "format": "When shuffle mode is $val",
+          "type": "communicate",
+          "valueType": "choice",
+          "valueChoices": [
+            "OFF",
+            "ON"
+          ],
+          "valueStateId": "ytmd.states.shuffleMode"
         }
       ],
       "states": [
@@ -242,6 +283,12 @@
           "type": "text",
           "desc": "YouTube Music repeat mode (NONE, ALL, ONE)",
           "default": "NONE"
+        },
+        {
+          "id": "ytmd.states.shuffleMode",
+          "type": "text",
+          "desc": "YouTube Music shuffle mode (OFF, ON)",
+          "default": "OFF"
         }
       ]
     }

--- a/config/entry.tp
+++ b/config/entry.tp
@@ -101,14 +101,24 @@
                 "language": "default",
                 "data": [
                   {
-                    "lineFormat": "Current audio state: "
+                    "lineFormat": "Current audio state: {$ytmd.choice.audioPlayback$}"
                   }
                 ]
               }
             ]
-          }
+          },
+          "data": [
+            {
+              "id": "ytmd.choice.audioPlayback",
+              "type": "choice",
+              "default": "Unmuted",
+              "valueChoices": [
+                "Muted",
+                "Unmuted"
+              ]
+            }
+          ]
         }
-        
       ],
       "events": [
         {
@@ -122,14 +132,32 @@
             "Pause"
           ],
           "valueStateId": "ytmd.states.playbackState"
+        },
+        {
+          "id": "ytmd.event.audioPlayback",
+          "name": "YouTube Music audio state changes",
+          "format": "When audio is $val",
+          "type": "communicate",
+          "valueType": "choice",
+          "valueChoices": [
+            "Muted",
+            "Unmuted"
+          ],
+          "valueStateId": "ytmd.states.mutedState"
         }
       ],
       "states": [
         {
           "id": "ytmd.states.playbackState",
           "type": "text",
-          "desc": "YouTube Music play state paused",
+          "desc": "YouTube Music play state (Play or Pause)",
           "default": "Pause"
+        },
+        {
+          "id": "ytmd.states.mutedState",
+          "type": "text",
+          "desc": "YouTube Music audio state (Mutes or Unmuted)",
+          "default": "Unmuted"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rm -rf ./dist",
-    "build": "npm run clean && npx tsc"
+    "build": "npm run clean && npx tsc",
+    "watch": "npx tsc --watch"
   },
   "devDependencies": {
     "@types/node": "^20.19.31",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,9 @@ import { YTMDClient } from "./services/ytmdClient";
 
     let isCurrentlyMuted = false;
     let currentRepeatMode = 0;
-
+    let currentShuffleMode = "OFF"; 
     ytmdClient.socketClient.addStateListener((state) => {
+      // console.log("YTMD SocketClient State:::::", state.player);
       const status = state.player?.trackState ? "Play" : "Pause";
 
       console.log("YTMD SocketClient Status:::::", status);
@@ -43,6 +44,12 @@ import { YTMDClient } from "./services/ytmdClient";
 
       tpClient.stateUpdate(TP_ACTIONS.ytmdRepeatMode, repeatModeStr);
       tpClient.stateUpdate(TP_STATES.ytmdRepeatMode, repeatModeStr);
+    });
+    
+    ytmdClient.socketClient.addStateListener((state) => {
+      const shuffleMode = currentShuffleMode;
+      tpClient.stateUpdate(TP_ACTIONS.ytmdShuffleMode, shuffleMode);
+      tpClient.stateUpdate(TP_STATES.ytmdShuffleMode, shuffleMode);
     });
 
     ytmdClient.socketClient.addConnectionStateListener((state) => {
@@ -79,8 +86,16 @@ import { YTMDClient } from "./services/ytmdClient";
           case "ytmd.action.volumeDown":
             await ytmdClient.restClient.volumeDown();
             break;
-          case "ymtd.action.repeatMode":
+          case "ytmd.action.repeatMode":
             await ytmdClient.restClient.repeatMode(currentRepeatMode);
+            break;
+          case "ytmd.action.shuffleMode":
+            if (currentShuffleMode === "OFF") {
+              currentShuffleMode = "ON";
+            } else {
+              currentShuffleMode = "OFF";
+            }
+            await ytmdClient.restClient.shuffle();
             break;
           default:
             console.log(`No handler for action ID:  ${actionId}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,11 @@ import { YTMDClient } from './services/ytmdClient';
           case "ytmd.action.play/pause":
             await ytmdClient.restClient.playPause();
             break;
+          case "ytmd.action.nextTrack":
+            await ytmdClient.restClient.next();
+            break;
+          case "ytmd.action.prevTrack":
+            await ytmdClient.restClient.previous();
           default:
             console.log(`No handler for action ID:  ${actionId}`);
             break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,10 @@ import { YTMDClient } from './services/ytmdClient';
     const ytmdClient = new YTMDClient();
 
     ytmdClient.socketClient.addStateListener((state) => {
-      // console.log("YTMD SocketClient State:::::", state);
-      const status = state.player.trackState ? "PLAYING" : "PAUSED";
+      const status = state.player.trackState ? "Play" : "Pause";
       console.log("YTMD SocketClient Status:::::", status);
       tpClient.stateUpdate("ytmd.action.play/pause", status);
+      tpClient.stateUpdate("ytmd.states.playbackState", status);
     });
 
     ytmdClient.socketClient.addConnectionStateListener((state) => {
@@ -23,6 +23,7 @@ import { YTMDClient } from './services/ytmdClient';
     tpClient.on("Action", async (data: any) => {
       console.log("TPClient Action:::::", data);
       const actionId = data.actionId;
+      console.log("TPClient Action ID:::::", actionId);
       try {
         switch (actionId) {
           case "ytmd.action.play/pause":

--- a/src/services/touchPortalClient.ts
+++ b/src/services/touchPortalClient.ts
@@ -8,17 +8,21 @@ export const TP_ACTIONS = {
   ytmdVolumeUp: "ytmd.action.volumeUp",
   ytmdVolumeDown: "ytmd.action.volumeDown",
   ytmdRepeatMode: "ytmd.action.repeatMode",
+  ytmdShuffleMode: "ytmd.action.shuffleMode",
 };
 
 export const TP_EVENTS = {
   ytmdEventPlayback: "ytmd.event.playback",
   ytmdEventAudioPlayback: "ytmd.event.audioPlayback",
+  ytmdEventRepeatMode: "ytmd.event.repeatMode",
+  ytmdEventShuffleMode: "ytmd.event.shuffleMode",
 };
 
 export const TP_STATES = {
   ytmdPlaybackState: "ytmd.states.playbackState",
   ytmdMutedState: "ytmd.states.mutedState",
   ytmdRepeatMode: "ytmd.states.repeatMode",
+  ytmdShuffleMode: "ytmd.states.shuffleMode",
 };
 
 const PLUGIN_ID = 'ytmd_plugin_v2';

--- a/src/services/touchPortalClient.ts
+++ b/src/services/touchPortalClient.ts
@@ -1,5 +1,26 @@
 import * as TouchPortalApi from 'touchportal-api';
 
+export const TP_ACTIONS = {
+  ytmdPlayPause: "ytmd.action.play/pause",
+  ytmdNextTrack: "ytmd.action.nextTrack",
+  ytmdPrevTrack: "ytmd.action.prevTrack",
+  ytmdMuteUnmute: "ytmd.action.mute/unmute",
+  ytmdVolumeUp: "ytmd.action.volumeUp",
+  ytmdVolumeDown: "ytmd.action.volumeDown",
+  ytmdRepeatMode: "ytmd.action.repeatMode",
+};
+
+export const TP_EVENTS = {
+  ytmdEventPlayback: "ytmd.event.playback",
+  ytmdEventAudioPlayback: "ytmd.event.audioPlayback",
+};
+
+export const TP_STATES = {
+  ytmdPlaybackState: "ytmd.states.playbackState",
+  ytmdMutedState: "ytmd.states.mutedState",
+  ytmdRepeatMode: "ytmd.states.repeatMode",
+};
+
 const PLUGIN_ID = 'ytmd_plugin_v2';
 export async function touchPortalClient(): Promise<any> {
   console.log('Initializing TouchPortal client...');

--- a/src/services/touchPortalClient.ts
+++ b/src/services/touchPortalClient.ts
@@ -9,6 +9,7 @@ export const TP_ACTIONS = {
   ytmdVolumeDown: "ytmd.action.volumeDown",
   ytmdRepeatMode: "ytmd.action.repeatMode",
   ytmdShuffleMode: "ytmd.action.shuffleMode",
+  ytmdLikeDislike: "ytmd.action.like/dislike",
 };
 
 export const TP_EVENTS = {
@@ -16,6 +17,7 @@ export const TP_EVENTS = {
   ytmdEventAudioPlayback: "ytmd.event.audioPlayback",
   ytmdEventRepeatMode: "ytmd.event.repeatMode",
   ytmdEventShuffleMode: "ytmd.event.shuffleMode",
+  ytmdEventLikeDislike: "ytmd.event.likeDislike",
 };
 
 export const TP_STATES = {
@@ -23,6 +25,7 @@ export const TP_STATES = {
   ytmdMutedState: "ytmd.states.mutedState",
   ytmdRepeatMode: "ytmd.states.repeatMode",
   ytmdShuffleMode: "ytmd.states.shuffleMode",
+  ytmdLikeDislike: "ytmd.states.likeDislike",
 };
 
 const PLUGIN_ID = 'ytmd_plugin_v2';

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,12 @@
+import 'ytmdesktop-ts-companion';
+
+/**
+ * Add the `muted` property missing the Player interface but is present
+ * in the `PlayerState` interface in the YouTube Music Desktop interface
+ * @see {@link https://github.com/ytmdesktop/ytmdesktop/blob/development/src/main/player-state-store/index.ts}
+ */
+declare module 'ytmdesktop-ts-companion' {
+  interface Player {
+    muted: boolean;
+  }
+}


### PR DESCRIPTION
- fixed the issue where the state for the even of pause/play was not updating properly.

**feat:** adding actions to change tracks**
  - added actions for to change tracks
    - `ytmd.action.nextTrack` to change to the next track
    - `ytmd.action.prevTrack` to change to the previous track
  - added starting steps to toggle the ablity to Mute and Unmute the player
   
**feat: added mute and unmute functionality**
  - Added the abiltiy to mute and unmute.
  - Added delay in `syncNewAuthToken` to give the user more time to allow the token to be set

**feat: Added Volume Control and Repeat Mode**
- Added the ability to control the volume up and down
- Added the ability to change the Repeat Mode: `None`, `One`, `All`.
- Started adding the Actions, Events and States into exported `consts` for better readability.

**feat: Added shuffle and repeat mode**
- Added the ability to change the repeat mode of the player
- Added the ability to toggle on/off the shuffle mode 

** feat: Added Like and Dislike functionality**
- Added the ability for user to Like and Dislike a song/video