### PR TITLE
refactor: ytmdClient and touchPortalClient refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/bcarbajal23/touchportal-ytmd-plugin-v2.git"
   },
-  "license": "ISC",
+  "license": "GPL-3.0",
   "author": "Carlos Carbajal",
   "type": "commonjs",
   "main": "index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,5 @@
-import {
-  touchPortalClient,
-  TP_ACTIONS,
-  TP_STATES,
-} from "./services/touchPortalClient";
+import { touchPortalClient } from "./services/touchPortalClient";
+import { TP_ACTIONS, TP_STATES } from "./services/utils/tpConstants";
 import { YTMDClient } from "./services/ytmdClient";
 
 (async () => {

--- a/src/services/touchPortalClient.ts
+++ b/src/services/touchPortalClient.ts
@@ -1,35 +1,7 @@
 import * as TouchPortalApi from 'touchportal-api';
+import { PLUGIN_ID } from './utils/tpConstants';
 
-export const TP_ACTIONS = {
-  ytmdPlayPause: "ytmd.action.play/pause",
-  ytmdNextTrack: "ytmd.action.nextTrack",
-  ytmdPrevTrack: "ytmd.action.prevTrack",
-  ytmdMuteUnmute: "ytmd.action.mute/unmute",
-  ytmdVolumeUp: "ytmd.action.volumeUp",
-  ytmdVolumeDown: "ytmd.action.volumeDown",
-  ytmdRepeatMode: "ytmd.action.repeatMode",
-  ytmdShuffleMode: "ytmd.action.shuffleMode",
-  ytmdLikeDislike: "ytmd.action.like/dislike",
-};
-
-export const TP_EVENTS = {
-  ytmdEventPlayback: "ytmd.event.playback",
-  ytmdEventAudioPlayback: "ytmd.event.audioPlayback",
-  ytmdEventRepeatMode: "ytmd.event.repeatMode",
-  ytmdEventShuffleMode: "ytmd.event.shuffleMode",
-  ytmdEventLikeDislike: "ytmd.event.likeDislike",
-};
-
-export const TP_STATES = {
-  ytmdPlaybackState: "ytmd.states.playbackState",
-  ytmdMutedState: "ytmd.states.mutedState",
-  ytmdRepeatMode: "ytmd.states.repeatMode",
-  ytmdShuffleMode: "ytmd.states.shuffleMode",
-  ytmdLikeDislike: "ytmd.states.likeDislike",
-};
-
-const PLUGIN_ID = 'ytmd_plugin_v2';
-export async function touchPortalClient(): Promise<any> {
+export async function touchPortalClient(): Promise<InstanceType<typeof TouchPortalApi.Client>> {
   console.log('Initializing TouchPortal client...');
   
   const touchPortalClient = new TouchPortalApi.Client();

--- a/src/services/utils/tpConstants.ts
+++ b/src/services/utils/tpConstants.ts
@@ -1,0 +1,30 @@
+export const PLUGIN_ID = 'ytmd_plugin_v2';
+
+export const TP_ACTIONS = {
+  ytmdPlayPause: "ytmd.action.play/pause",
+  ytmdNextTrack: "ytmd.action.nextTrack",
+  ytmdPrevTrack: "ytmd.action.prevTrack",
+  ytmdMuteUnmute: "ytmd.action.mute/unmute",
+  ytmdVolumeUp: "ytmd.action.volumeUp",
+  ytmdVolumeDown: "ytmd.action.volumeDown",
+  ytmdRepeatMode: "ytmd.action.repeatMode",
+  ytmdShuffleMode: "ytmd.action.shuffleMode",
+  ytmdLikeDislike: "ytmd.action.like/dislike",
+} as const;
+
+export const TP_EVENTS = {
+  ytmdEventPlayback: "ytmd.event.playback",
+  ytmdEventAudioPlayback: "ytmd.event.audioPlayback",
+  ytmdEventRepeatMode: "ytmd.event.repeatMode",
+  ytmdEventShuffleMode: "ytmd.event.shuffleMode",
+  ytmdEventLikeDislike: "ytmd.event.likeDislike",
+} as const;
+
+export const TP_STATES = {
+  ytmdPlaybackState: "ytmd.states.playbackState",
+  ytmdMutedState: "ytmd.states.mutedState",
+  ytmdRepeatMode: "ytmd.states.repeatMode",
+  ytmdShuffleMode: "ytmd.states.shuffleMode",
+  ytmdLikeDislike: "ytmd.states.likeDislike",
+} as const;
+


### PR DESCRIPTION
- refactored `ytmdClient.ts`
  - changed construtor to have host and port passed in as parameters.
  - rewrote how the `syncNewAuthToken` handles getting a new token.

- refactored `touchPortalClient.ts`
  - extracted the constants into `tpConstants.ts`
  - changed return type of the client to `InstanceType<typeof TouchPortalApi.Client>`