### PR TITLE
Indexts refactor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,15 @@ import { touchPortalClient } from "./services/touchPortalClient";
 import { TP_ACTIONS, TP_STATES } from "./services/utils/tpConstants";
 import { YTMDClient } from "./services/ytmdClient";
 
+
+const playerState = {
+  isCurrentlyMuted: false,
+  currentRepeatMode: 0,
+  currentShuffleMode: "OFF",
+  likeDislikeActionSet:"",
+  lastPlayState: "",
+};
+
 (async () => {
   try {
     const tpClient = await touchPortalClient();
@@ -13,6 +22,7 @@ import { YTMDClient } from "./services/ytmdClient";
     let likeDislikeActionSet = "";
     let lastPlayState = "";
 
+    
     // State listener for Playing and Pausing Player
     ytmdClient.socketClient.addStateListener((state) => {
       const status = state.player?.trackState ? "Play" : "Pause";

--- a/src/services/utils/actionHandlers.ts
+++ b/src/services/utils/actionHandlers.ts
@@ -1,10 +1,12 @@
 import { YTMDClient } from "../ytmdClient";
-import { TP_ACTIONS } from "./tpConstants";
+import { TP_ACTIONS, TP_STATES } from "./tpConstants";
 
-type ActionHandler = (data: any) => Promise<void> | void;
+export type ActionHandler = (data: any) => Promise<void> | void;
+
+export type ActionId = typeof TP_ACTIONS[ keyof typeof TP_ACTIONS ];
 
 export type ActionRegistry = {
-  [key in typeof TP_ACTIONS[keyof typeof TP_ACTIONS]]: ActionHandler;
+  [key in ActionId]: ActionHandler;
 };
 
 /**
@@ -16,9 +18,10 @@ export type ActionRegistry = {
  * @returns { ActionRegistry} A Mapping of all the Touch Portal Actions to the corresponding
  * YouTube Music Desktop App Rest Client actions.
  * 
+ * It will make it easier to add more actions later if more features are added.
  */
 export const createActionHandlers =
-  (ytmdClient: YTMDClient, playerState: any): ActionRegistry => {
+  (ytmdClient: YTMDClient, playerState: any, tpClient: any): ActionRegistry => {
     return {
       [ TP_ACTIONS.ytmdPlayPause ]: async () => {
         await ytmdClient.restClient.playPause();
@@ -43,14 +46,26 @@ export const createActionHandlers =
         await ytmdClient.restClient.volumeDown()
       },
       [ TP_ACTIONS.ytmdRepeatMode ]: async () => {
-        await ytmdClient.restClient.repeatMode(playerState.currentRepeatMode)
+        const rolloverRepeatMode = (playerState.currentRepeatMode + 1) % 3;
+        
+        await ytmdClient.restClient.repeatMode(rolloverRepeatMode);
       },
       [ TP_ACTIONS.ytmdShuffleMode ]: async () => {
+        /**
+         * Toggle shuffle mode ON and OFF. 
+         * The logic is moved here so that YTMD does not spam Touch Portal 
+         * with updating the shuttle state every second. This will only now
+         * update when the button is pressed.
+         */
+        
         if (playerState.currentShuffleMode === "OFF") {
           playerState.currentShuffleMode = "ON";
         } else {
           playerState.currentShuffleMode = "OFF";
         }
+        tpClient.stateUpdate(TP_ACTIONS.ytmdShuffleMode, playerState.currentShuffleMode);
+        tpClient.stateUpdate(TP_STATES.ytmdShuffleMode, playerState.currentShuffleMode);
+        
         await ytmdClient.restClient.shuffle();
       },
       [ TP_ACTIONS.ytmdLikeDislike ]: async (data) => {
@@ -60,15 +75,11 @@ export const createActionHandlers =
         )?.value;
         
         if (actionLikeDislikeState === "LIKE") {
-          playerState.likeDislikeActionSet =
-            actionLikeDislikeState === "LIKE" ? "LIKE" : "INDIFFERENT";
-          // YTMD Client handles the action setting of like.
           await ytmdClient.restClient.toggleLike();
         } else if (actionLikeDislikeState === "DISLIKE") {
-          playerState.likeDislikeActionSet =
-            actionLikeDislikeState === "DISLIKE" ? "DISLIKE" : "INDIFFERENT";
           await ytmdClient.restClient.toggleDislike();
         }
+        
       }
     };
   };

--- a/src/services/utils/actionHandlers.ts
+++ b/src/services/utils/actionHandlers.ts
@@ -1,0 +1,74 @@
+import { YTMDClient } from "../ytmdClient";
+import { TP_ACTIONS } from "./tpConstants";
+
+type ActionHandler = (data: any) => Promise<void> | void;
+
+export type ActionRegistry = {
+  [key in typeof TP_ACTIONS[keyof typeof TP_ACTIONS]]: ActionHandler;
+};
+
+/**
+ * Action Handlers Registry for Touch Portal to interface and communicate with
+ * the YouTube Music Desktop App.
+ * @param ytmdClient - ytmd client used to call the Rest Client to perform actions
+ *  i.e. toggle play/pause, like or dislike a track, etc.
+ * @param playerState - current state of the player
+ * @returns { ActionRegistry} A Mapping of all the Touch Portal Actions to the corresponding
+ * YouTube Music Desktop App Rest Client actions.
+ * 
+ */
+export const createActionHandlers =
+  (ytmdClient: YTMDClient, playerState: any): ActionRegistry => {
+    return {
+      [ TP_ACTIONS.ytmdPlayPause ]: async () => {
+        await ytmdClient.restClient.playPause();
+      },
+      [ TP_ACTIONS.ytmdNextTrack ]: async () => {
+        await ytmdClient.restClient.next();
+      },
+      [ TP_ACTIONS.ytmdPrevTrack ]: async () => {
+        await ytmdClient.restClient.previous();
+      },
+      [ TP_ACTIONS.ytmdMuteUnmute ]: async () => {
+        if (playerState.isCurrentlyMuted) {
+          await ytmdClient.restClient.unmute();
+        } else {
+          await ytmdClient.restClient.mute();
+        }
+      },
+      [ TP_ACTIONS.ytmdVolumeUp ]: async () => {
+        await ytmdClient.restClient.volumeUp();
+      },
+      [ TP_ACTIONS.ytmdVolumeDown ]: async () => {
+        await ytmdClient.restClient.volumeDown()
+      },
+      [ TP_ACTIONS.ytmdRepeatMode ]: async () => {
+        await ytmdClient.restClient.repeatMode(playerState.currentRepeatMode)
+      },
+      [ TP_ACTIONS.ytmdShuffleMode ]: async () => {
+        if (playerState.currentShuffleMode === "OFF") {
+          playerState.currentShuffleMode = "ON";
+        } else {
+          playerState.currentShuffleMode = "OFF";
+        }
+        await ytmdClient.restClient.shuffle();
+      },
+      [ TP_ACTIONS.ytmdLikeDislike ]: async (data) => {
+        // Grab the current like/dislike state of the current song/video
+        const actionLikeDislikeState = data.data.find(
+              (item: any) => item.id === "ytmd.choice.likeDislike",
+        )?.value;
+        
+        if (actionLikeDislikeState === "LIKE") {
+          playerState.likeDislikeActionSet =
+            actionLikeDislikeState === "LIKE" ? "LIKE" : "INDIFFERENT";
+          // YTMD Client handles the action setting of like.
+          await ytmdClient.restClient.toggleLike();
+        } else if (actionLikeDislikeState === "DISLIKE") {
+          playerState.likeDislikeActionSet =
+            actionLikeDislikeState === "DISLIKE" ? "DISLIKE" : "INDIFFERENT";
+          await ytmdClient.restClient.toggleDislike();
+        }
+      }
+    };
+  };


### PR DESCRIPTION
**refactor: added actionHandlers map**
- Added `ActionHandler` to map Touch Portal actions to YouTube Music
  Desktop app client actions. This will help clean up the giant `switch`
  in `index.ts`

**refactor: refactored index.js and added to actionHandlers.js**
- Refactored `index.js` by removing the big switch statement in favor of
  using the new `ActionRegistry`. The `ActionRegistry` is just map of all the
  actions for the the plugin.
- `ActionRegisty` handles the calling to YTMD RestClient API.
- index.js now only handles statement with the exception of a few states
  being updated from the `ActionRegistry`.
- Optimized `ytmdClient.socketClient.addStateListener(...)` by
  consolidating all the action state updates into one listener.
- Optimized the `ytmdClient.socketClient.addStateListener(...)` by only
  firing calls to `Touch Portal` when changes to the player state have
  been made. Since `ytmdClient.socketClient.addStateListener(...)` fires
  every second, this will keep `ytmdClient` from flooding `Touch Portal`
  with HTTP requests.