### PR TITLE
1.2.1

### DIFF
--- a/config/entry.tp
+++ b/config/entry.tp
@@ -1,6 +1,6 @@
 {
   "sdk": 10,
-  "version": 10200,
+  "version": 10201,
   "name": "Youtube Music Desktop Plugin V2",
   "id": "ytmd_plugin_v2",
   "configuration": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "touchportal-ytmd-plugin-v2",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "touchportal-ytmd-plugin-v2",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "GPL-3.0",
       "dependencies": {
         "touchportal-api": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "touchportal-ytmd-plugin-v2",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Touch Portal plugin for Youtube Music Desktop App",
   "homepage": "https://github.com/bcarbajal23/touchportal-ytmd-plugin-v2#readme",
   "bugs": {


### PR DESCRIPTION
Release to update some vulnerable dependencies 

- Bumps [lodash](https://github.com/lodash/lodash) from 4.17.23 to 4.18.1
- Bumps [socket.io-parser](https://github.com/socketio/socket.io) from 4.2.5 to 4.2.6.